### PR TITLE
fix: 修复了配方运行间会停顿 1t 的问题

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/RecipeLogic.java
@@ -171,7 +171,8 @@ public class RecipeLogic extends MachineTrait implements IWorkable, IFancyToolti
         } else if (status != IDLE && lastRecipe != null) {
             if (progress < duration) {
                 handleRecipeWorking();
-            } else {
+            }
+            if (progress >= duration) {
                 machine.onRecipeFinish();
                 onRecipeFinish();
             }


### PR DESCRIPTION
群里今晚提到的 bug，屠宰场这种吃满能源的机器，如果供电是 2A，能源仓是 2A，则发电机内的缓存会逐渐耗尽然后多方块判定能量不足。

问题出在 RecipeLogic 这里，https://github.com/GregTech-Odyssey/GregTech-Modern/commit/e2f55663357dd117919b254ad9b19e7bac79af65 这次 commit 好像给改坏了（

handleRecipeWorking 里面会修改 progress，所以这个两个 if 虽然看起来条件相反但是不能改成 if-else，不然会有 1tick 只运行了 onRecipeFinish 而没有 handleRecipeWorking，也就是两次配方运行间有 1tick 的间隔，导致能量供不上