### PR TITLE
fix: 使用 MC 原版的 ctrl 逻辑以统一不同平台的行为

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ClickDataMixin.java
+++ b/src/main/java/com/gregtechceu/gtceu/core/mixins/ldlib/ClickDataMixin.java
@@ -1,0 +1,33 @@
+package com.gregtechceu.gtceu.core.mixins.ldlib;
+
+import com.lowdragmc.lowdraglib.gui.util.ClickData;
+
+import net.minecraft.client.gui.screens.Screen;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = ClickData.class, remap = false)
+public class ClickDataMixin {
+
+    @Mutable
+    @Shadow(remap = false)
+    @Final
+    public boolean isShiftClick;
+
+    @Mutable
+    @Shadow(remap = false)
+    @Final
+    public boolean isCtrlClick;
+
+    @Inject(method = "<init>()V", at = @At("RETURN"), remap = false)
+    private void gtceu$useVanillaModifierKeys(CallbackInfo ci) {
+        isShiftClick = Screen.hasShiftDown();
+        isCtrlClick = Screen.hasControlDown();
+    }
+}

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTUtil.java
@@ -12,7 +12,7 @@ import com.gregtechceu.gtceu.data.recipe.CustomTags;
 
 import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -43,11 +43,9 @@ import net.minecraftforge.fluids.FluidType;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import com.google.common.collect.ImmutableList;
-import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.datafixers.util.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.lwjgl.glfw.GLFW;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -375,27 +373,21 @@ public class GTUtil {
 
     public static boolean isShiftDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_SHIFT) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_SHIFT);
+            return Screen.hasShiftDown();
         }
         return false;
     }
 
     public static boolean isCtrlDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_CONTROL) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_RIGHT_CONTROL);
+            return Screen.hasControlDown();
         }
         return false;
     }
 
     public static boolean isAltDown() {
         if (GTCEu.isClientSide()) {
-            var id = Minecraft.getInstance().getWindow().getWindow();
-            return InputConstants.isKeyDown(id, GLFW.GLFW_KEY_LEFT_ALT) ||
-                    InputConstants.isKeyDown(id, GLFW.GLFW_KEY_RIGHT_ALT);
+            return Screen.hasAltDown();
         }
         return false;
     }

--- a/src/main/resources/gtceu.mixins.json
+++ b/src/main/resources/gtceu.mixins.json
@@ -12,6 +12,7 @@
     "LevelRendererMixin",
     "ModelManagerMixin",
     "MultiPlayerGameModeMixin",
+    "ldlib.ClickDataMixin",
     "xaerominimap.HighlighterRegistryMixin",
     "xaerominimap.MinimapFBORendererMixin",
     "xaeroworldmap.GuiMapMixin",


### PR DESCRIPTION
看起来 GTM 上游代码也有同样的问题，还没搜到相关 issue，现在这里 PR 一下，上游那边之后再发。

问题是 GTM 和 ldlib 在判断 ctrl 的时候是自己写了一套按键判断，没复用 MC 原版代码里的轮子（不知道为啥他俩不这么做），导致没有针对 macOS 平台进行特判，MC 原版 `net.minecraft.client.gui.screens.Screen` 中的轮子是：

```java
   public static boolean hasControlDown() {
      if (Minecraft.ON_OSX) {
         return InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 343) || InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 347);
      } else {
         return InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 341) || InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), 345);
      }
   }
```

这套是符合 macOS 用户逻辑的，即 windows 上所谓的 Ctrl 在 macOS 上应该是 command 而非同一个按键码代表的 control。

如果不改的话，GT 相关的 “Ctrl” 在 macOS 上要按 control，但使用了原版轮子的其他 mod 所谓的 “Ctrl“ 要按 command。一个体现是：

<img width="803" height="230" alt="1d165694070e48a0ba6448e3bd7726d0" src="https://github.com/user-attachments/assets/f204d416-4c87-4001-b629-142886432d87" />

这个 AE 原版逻辑用的是 hasControlDown，所以这个 Ctrl 要按 command。

<img width="359" height="190" alt="19bb22fc2b47736e111f8a93bf321ec4" src="https://github.com/user-attachments/assets/58d2743f-b7e6-4a4a-a887-5716fb6e75e9" />

这个是 GTOCore 里新加的逻辑，用的 GTUtil 提供的轮子，所以这个 Ctrl 要按 control。

这个 PR 统一成原版逻辑了，即 macOS 上用 command 代表 Ctrl。顺便把 shift 和 alt 功能键也改为原版逻辑这样代码更整齐。然后用 mixin 把 ldlib ClickData 里硬编码的 isShiftClick 和 isCtrlClick 也改成原版的判断了。

改之后的行为测试过了，符合预期。