### PR TITLE
fix: 修复流体储罐销毁模式无条件销毁任何流体的问题

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/trait/NotifiableFluidTank.java
@@ -343,17 +343,23 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
     public int fillInternal(FluidStack resource, FluidAction action) {
         if (resource.isEmpty()) return 0;
         var copied = resource.copy();
+        boolean canVoidResource = false;
         CustomFluidTank existingStorage = null;
         if (!allowSameFluids) {
             for (var storage : storages) {
                 if (!storage.getFluid().isEmpty() && storage.getFluid().isFluidEqual(resource)) {
                     existingStorage = storage;
+                    canVoidResource = true;
                     break;
                 }
             }
         }
         if (existingStorage == null) {
             for (var storage : storages) {
+                boolean canFillStorage = storage.isFluidValid(resource) && (storage.getFluid().isEmpty() || storage.getFluid().isFluidEqual(resource));
+                if (canFillStorage) {
+                    canVoidResource = true;
+                }
                 var filled = storage.fill(copied.copy(), action);
                 if (filled > 0) {
                     copied.shrink(filled);
@@ -366,7 +372,7 @@ public class NotifiableFluidTank extends NotifiableRecipeHandlerTrait<FluidIngre
         } else {
             copied.shrink(existingStorage.fill(copied.copy(), action));
         }
-        return resource.getAmount() - (isVoiding ? 0 : copied.getAmount());
+        return resource.getAmount() - (isVoiding && canVoidResource ? 0 : copied.getAmount());
     }
 
     @NotNull


### PR DESCRIPTION
目前版本的 GTM 如果在流体储罐开启了销毁的情况下会无条件销毁任何试图进入的流体。

比如有一个储罐存储了氧气，开启了销毁溢出，则如果试图向储罐中通入氢气，这些氢气都会被销毁。

这个 PR 添加了额外判断，只有本可以存入，但因为空间大小限制存不下了的情况（溢出）会进行销毁，其他情况不进行销毁。