### PR TITLE
fix: 在维护仓得到维护后立即重新尝试执行配方

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/MaintenanceHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/MaintenanceHatchPartMachine.java
@@ -118,8 +118,17 @@ public class MaintenanceHatchPartMachine extends WorkableTieredPartMachine imple
     //////////////////////////////////////
     @Override
     public void setMaintenanceProblems(byte problems) {
+        boolean hadProblems = hasMaintenanceProblems();
         this.maintenanceProblems = problems;
         updateMaintenanceSubscription();
+        if (hadProblems && !hasMaintenanceProblems()) {
+            for (var controller : getControllers()) {
+                if (controller instanceof IRecipeLogicMachine recipeLogicMachine) {
+                    recipeLogicMachine.getRecipeLogic().markLastRecipeDirty();
+                    recipeLogicMachine.getRecipeLogic().updateTickSubscription();
+                }
+            }
+        }
         requestSync();
     }
 


### PR DESCRIPTION
现在的维护仓在维护后主方块仍然会显示需要维护，需要重新启动更新一次后才能跑配方。在蒸汽机器上尤为别扭，蒸汽机器没有启动按钮，只能重新放一下输入或者重新成型一下机器才能继续跑配方。

这个 PR 在维护仓得到维护后触发一次 recipe logic 的 updateTickSubscription 来让配方继续运行，和其他仓室内容发生变化后进行通知一样。