### PR TITLE
fix: 两个多方块同时成型使得不可共享方块可以被共享（需要帮助）

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/multiblock/MultiblockControllerMachine.java
@@ -205,6 +205,34 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
         return formedAmount;
     }
 
+    private void releaseReservedParts(MultiblockState state, MultiblockWorldData worldData) {
+        if (!state.reservedParts.isEmpty()) {
+            worldData.releaseReservedParts(state.reservedParts, getPos().asLong());
+            state.reservedParts.clear();
+        }
+    }
+
+    private void releaseReservedParts() {
+        if (getLevel() instanceof ServerLevel serverLevel) {
+            var worldData = MultiblockWorldData.getOrCreate(serverLevel);
+            releaseReservedParts(getMultiblockState(), worldData);
+            for (var subState : getSubMultiblockState()) {
+                if (subState != null) {
+                    releaseReservedParts(subState, worldData);
+                }
+            }
+        }
+    }
+
+    private void releaseFailedSubPatternReservations(MultiblockWorldData worldData) {
+        var subStates = getSubMultiblockState();
+        for (int i = 0; i < subStates.length; i++) {
+            if (!formeds[i] && subStates[i] != null) {
+                releaseReservedParts(subStates[i], worldData);
+            }
+        }
+    }
+
     @Override
     public boolean checkPattern() {
         if (waitingTime < 1) {
@@ -232,6 +260,9 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
                             }
                             subMultiblockState[i] = subState;
                         }
+                        if (getLevel() instanceof ServerLevel serverLevel) {
+                            releaseFailedSubPatternReservations(MultiblockWorldData.getOrCreate(serverLevel));
+                        }
                     }
                     if (getLevel() instanceof ServerLevel serverLevel) {
                         var c = state.blockEntityCache.longStream().mapToObj(BlockPos::of).toList();
@@ -248,7 +279,9 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
             if (result) {
                 waitingTime = 0;
                 return true;
-            } else if (hasCheckButton()) {
+            }
+            releaseReservedParts();
+            if (hasCheckButton()) {
                 waitingTime = 10;
             } else {
                 waitingTime = 1;
@@ -272,6 +305,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
             if (checkPatternWithTryLock()) {
                 serverLevel.getServer().execute(() -> {
                     if (requiresServerCheck() && !checkPatternWithLock()) {
+                        releaseReservedParts();
                         simpleLock = false;
                         return;
                     }
@@ -333,6 +367,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
             Arrays.sort(parts, sorter);
         }
         updatePartPositions();
+        releaseReservedParts();
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -354,6 +389,7 @@ public class MultiblockControllerMachine extends MetaMachine implements IMultiCo
         modules.clear();
         this.parts = new IMultiPart[0];
         updatePartPositions();
+        releaseReservedParts();
         if (getLevel() instanceof ServerLevel serverLevel) {
             serverLevel.getServer().tell(new TickTask(1, this::onStructureInvalidAfter));
         }

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/BlockPattern.java
@@ -157,11 +157,24 @@ public class BlockPattern {
                                                 return false;
                                             }
                                             // add detected parts
-                                            if (part.isFormed() && !part.canShared() && !part.hasController(worldState.controllerPos)) {
-                                                // check part can be shared
-                                                success = false;
-                                                worldState.setError(MultiblockState.SHARE_ERROR);
-                                            } else {
+                                            if (!part.hasController(worldState.controllerPos) && !part.canShared()) {
+                                                var controllerPos = worldState.controllerPos.asLong();
+                                                if (part.isFormed()) {
+                                                    success = false;
+                                                    worldState.setError(MultiblockState.SHARE_ERROR);
+                                                } else if (worldState.world instanceof ServerLevel serverLevel) {
+                                                    var worldData = MultiblockWorldData.getOrCreate(serverLevel);
+                                                    var alreadyReserved = worldData.isReservedBy(posLong, controllerPos);
+                                                    if (worldData.isReservedByOther(posLong, controllerPos) ||
+                                                            !worldData.reservePart(posLong, controllerPos)) {
+                                                        success = false;
+                                                        worldState.setError(MultiblockState.SHARE_ERROR);
+                                                    } else if (!alreadyReserved) {
+                                                        worldState.reservedParts.add(posLong);
+                                                    }
+                                                }
+                                            }
+                                            if (success) {
                                                 matchContext.getParts().add(part);
                                             }
                                         }

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockState.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockState.java
@@ -54,6 +54,7 @@ public class MultiblockState {
     @Getter
     public final PatternMatchContext matchContext;
     public final LongOpenHashSet cache = new LongOpenHashSet();
+    public final LongOpenHashSet reservedParts = new LongOpenHashSet();
 
     public final List<PatternError> errorRecord = new ArrayList<>();
 
@@ -89,6 +90,7 @@ public class MultiblockState {
         this.matchContext.merge(state.matchContext);
         this.cache.addAll(state.cache);
         this.blockEntityCache.addAll(state.blockEntityCache);
+        this.reservedParts.addAll(state.reservedParts);
     }
 
     public void clear() {
@@ -97,6 +99,7 @@ public class MultiblockState {
         this.layerCount.clear();
         this.cache.clear();
         this.blockEntityCache.clear();
+        this.reservedParts.clear();
     }
 
     public void clearCache() {

--- a/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldData.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/pattern/MultiblockWorldData.java
@@ -11,6 +11,7 @@ import com.gregtechceu.gtceu.utils.TaskHandler;
 import net.minecraft.server.level.ServerLevel;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongCollection;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import org.jetbrains.annotations.Nullable;
 
@@ -56,6 +57,7 @@ public class MultiblockWorldData {
      */
     private final Long2ObjectOpenHashMap<Set<MultiblockState>> chunkPosMapping = new Long2ObjectOpenHashMap<>();
     private final Set<IMultiController> controllers = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<Long, Long> reservedParts = new ConcurrentHashMap<>();
 
     public MultiblockState[] getControllersInChunk(long chunkPos) {
         synchronized (chunkPosMapping) {
@@ -102,6 +104,27 @@ public class MultiblockWorldData {
         }
     }
 
+    public boolean reservePart(long partPos, long controllerPos) {
+        var owner = reservedParts.putIfAbsent(partPos, controllerPos);
+        return owner == null || owner == controllerPos;
+    }
+
+    public boolean isReservedBy(long partPos, long controllerPos) {
+        var owner = reservedParts.get(partPos);
+        return owner != null && owner == controllerPos;
+    }
+
+    public boolean isReservedByOther(long partPos, long controllerPos) {
+        var owner = reservedParts.get(partPos);
+        return owner != null && owner != controllerPos;
+    }
+
+    public void releaseReservedParts(LongCollection partPositions, long controllerPos) {
+        for (var iterator = partPositions.iterator(); iterator.hasNext();) {
+            reservedParts.remove(iterator.nextLong(), controllerPos);
+        }
+    }
+
     private void searchingTask() {
         if (GTCEu.canGetServerLevel()) {
             var arr = controllers.toArray(new IMultiController[0]);
@@ -116,6 +139,7 @@ public class MultiblockWorldData {
         subscription = ITickSubscription.unsubscribe(subscription);
         controllers.clear();
         chunkPosMapping.clear();
+        reservedParts.clear();
         taskHandler.unsubscribe();
     }
 }


### PR DESCRIPTION
ai code，我没看明白，挂在这里供他人修复参考之用

试图解决 https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1481

简单讲就是同tick 两个多方块同时成型，判定到了同一个不可共享方块，但是由于没有锁（或者没有竞态），导致这个方块同时被两边都判定通过

```mermaid
sequenceDiagram
    participant W as "MultiblockWorldData"
    participant A as "Controller A"
    participant B as "Controller B"
    participant P as "Shared Non-shareable Part"
    participant M as "Main Thread"

    W->>A: asyncCheckPattern()
    W->>B: asyncCheckPattern()

    Note over A,B: A 和 B 在接近同一时刻开始异步结构检查

    A->>P: 检查共享部件
    Note right of A: 看到 P 当前属于“未成型”状态
    A->>A: 判定通过

    B->>P: 检查共享部件
    Note right of B: 也看到 P 当前属于“未成型”状态
    B->>B: 判定通过

    Note over A,B: 问题点：这里双方都通过了<br/>因为判定只拦“对方已成型”

    A->>M: 回主线程，执行 onStructureFormed()
    M->>P: P 归属到 A

    B->>M: 回主线程，执行 onStructureFormed()
    M->>P: P 又归属到 B / 或同时被两边认为有效

    Note over A,B: 最终效果：不可共享部件被两台机器同时吃到了

```

