### PR TITLE
Fix energy capability type guard

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/electric/HullMachine.java
@@ -42,7 +42,7 @@ public class HullMachine extends TieredPartMachine {
 
     @Override
     public @Nullable <T> T getGTCapability(Class<T> cap, @Nullable Direction side) {
-        if (cap == GTCapability.ENERGY_CONTAINER && side == null || side != getFrontFacing()) {
+        if (cap == GTCapability.ENERGY_CONTAINER && (side == null || side != getFrontFacing())) {
             return cap.cast(energyContainer);
         }
         return super.getGTCapability(cap, side);

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/EnergyHatchPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/EnergyHatchPartMachine.java
@@ -63,7 +63,7 @@ public class EnergyHatchPartMachine extends WorkableTieredIOPartMachine implemen
 
     @Override
     public @Nullable <T> T getGTCapability(Class<T> cap, @Nullable Direction side) {
-        if (cap == GTCapability.ENERGY_CONTAINER && side == null || side == getFrontFacing()) {
+        if (cap == GTCapability.ENERGY_CONTAINER && (side == null || side == getFrontFacing())) {
             return cap.cast(energyContainer);
         }
         return super.getGTCapability(cap, side);


### PR DESCRIPTION
Fixes P1-01 by grouping side checks behind the energy capability type guard in HullMachine and EnergyHatchPartMachine. Verified with `.\gradlew.bat compileJava`.