### PR TITLE
Fix CWUT parallel overflow saturation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ sourceSets {
     }
 }
 
+test {
+    useJUnitPlatform()
+}
+
 apply from: "$rootDir/gradle/scripts/jars.gradle"
 apply from: "$rootDir/gradle/scripts/moddevgradle.gradle"
 apply from: "$rootDir/gradle/scripts/repositories.gradle"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,7 @@
 dependencies {
     compileOnly(libs.jetbrains.annotations)
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,16 @@ modDevGradle = "2.0.141"
 jetbrains-annotations = "26.0.1"
 mixin = "0.8.7"
 lombok = "8.11"
+junit-jupiter = "5.11.4"
+junit-platform = "1.11.4"
 
 [libraries]
 minecraft               = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 minecraftForge          = { module = "net.minecraftforge:forge", version.ref = "minecraftForge" }
 jetbrains-annotations   = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 mixin                   = { module = "org.spongepowered:mixin", version.ref = "mixin" }
+junit-jupiter           = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 
 [plugins]
 modDevGradle            = { id = "net.neoforged.moddev.legacyforge", version.ref = "modDevGradle" }

--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/extension/CWUTRecipeExtension.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/extension/CWUTRecipeExtension.java
@@ -8,6 +8,7 @@ import com.gregtechceu.gtceu.api.recipe.handler.IRecipeHandlerHolder;
 import com.gregtechceu.gtceu.api.recipe.handler.RecipeHandlerUnit;
 import com.gregtechceu.gtceu.common.data.GTRecipeDataKeys;
 import com.gregtechceu.gtceu.utils.FormattingUtil;
+import com.gregtechceu.gtceu.utils.GTMath;
 
 import com.lowdragmc.lowdraglib.gui.widget.LabelWidget;
 import com.lowdragmc.lowdraglib.gui.widget.WidgetGroup;
@@ -65,7 +66,7 @@ public final class CWUTRecipeExtension extends RecipeExtension<Long> {
     public void setParallel(GTRecipe recipe, long parallel) {
         var cwu = recipe.getInputCWUt();
         if (cwu < 1) return;
-        recipe.setCWUt(cwu * parallel);
+        recipe.setCWUt(GTMath.saturatedMultiply(cwu, parallel));
     }
 
     @Override

--- a/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/GTMath.java
@@ -51,6 +51,14 @@ public class GTMath {
         }
     }
 
+    public static long saturatedMultiply(long left, long right) {
+        try {
+            return Math.multiplyExact(left, right);
+        } catch (ArithmeticException ignored) {
+            return (left < 0) == (right < 0) ? Long.MAX_VALUE : Long.MIN_VALUE;
+        }
+    }
+
     public static int hashInts(int... vals) {
         return Arrays.hashCode(vals);
     }

--- a/src/test/java/com/gregtechceu/gtceu/utils/GTMathTest.java
+++ b/src/test/java/com/gregtechceu/gtceu/utils/GTMathTest.java
@@ -1,0 +1,28 @@
+package com.gregtechceu.gtceu.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GTMathTest {
+
+    @Test
+    void saturatedMultiplyKeepsNonOverflowingProduct() {
+        assertEquals(12_000L, GTMath.saturatedMultiply(3_000, 4));
+    }
+
+    @Test
+    void saturatedMultiplyKeepsExactLongMaximumProduct() {
+        assertEquals(Long.MAX_VALUE, GTMath.saturatedMultiply(Long.MAX_VALUE, 1));
+    }
+
+    @Test
+    void saturatedMultiplyCapsPositiveLongOverflow() {
+        assertEquals(Long.MAX_VALUE, GTMath.saturatedMultiply(Long.MAX_VALUE / 2 + 1, 2));
+    }
+
+    @Test
+    void saturatedMultiplyCapsNegativeLongOverflow() {
+        assertEquals(Long.MIN_VALUE, GTMath.saturatedMultiply(Long.MAX_VALUE / 2 + 1, -2));
+    }
+}


### PR DESCRIPTION
## Summary
- Add saturated long multiplication helper for GTMath
- Use it when scaling CWUt in CWUTRecipeExtension.setParallel to avoid long wraparound into negative/zero computation requirements
- Add focused GTMath tests for non-overflow, exact max, and overflow saturation cases

## Verification
- .\gradlew.bat test --tests com.gregtechceu.gtceu.utils.GTMathTest
- .\gradlew.bat compileJava