### PR TITLE
Fix research station CWU progress

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/ResearchStationMachine.java
@@ -31,7 +31,13 @@ public class ResearchStationMachine extends WorkableElectricMultiblockMachine {
         long cwu = super.requestCWU(cwut, simulate);
         if (!simulate && cwu >= cwut) {
             var progress = getRecipeLogic().getProgress();
-            getRecipeLogic().setProgress(progress + (int) Math.min(getRecipeLogic().getMaxProgress() - progress, cwu));
+            long remainingProgressAfterBaseTick = (long) getRecipeLogic().getMaxProgress() - progress - 1;
+            if (remainingProgressAfterBaseTick > 0) {
+                long extraProgress = Math.min(remainingProgressAfterBaseTick, cwu - 1);
+                if (extraProgress > 0) {
+                    getRecipeLogic().setProgress(progress + (int) extraProgress);
+                }
+            }
         }
         return cwu;
     }


### PR DESCRIPTION
## Summary
- account for RecipeLogic's base per-tick progress when Research Station advances by consumed CWU
- keep CWUt=1 behavior unchanged and avoid overshooting the recipe duration on the final tick

## Verification
- git diff --check
- .\gradlew.bat compileJava --no-daemon --console=plain