### PR TITLE
Fix custom item handler clearing sparse reads

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/transfer/item/CustomItemStackHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/transfer/item/CustomItemStackHandler.java
@@ -253,6 +253,7 @@ public class CustomItemStackHandler extends AbstractDataSerializable implements 
 
     public void deserializeNBT(CompoundTag nbt) {
         setSize(Math.max(size, nbt.getInt("Size")));
+        Arrays.fill(stacks, ItemStack.EMPTY);
         ListTag tagList = nbt.getList("Items", Tag.TAG_COMPOUND);
         for (int i = 0; i < tagList.size(); i++) {
             CompoundTag itemTags = tagList.getCompound(i);
@@ -283,6 +284,7 @@ public class CustomItemStackHandler extends AbstractDataSerializable implements 
     @Override
     public void readBuf(LogicalSide side, @NotNull FriendlyByteBuf data) {
         setSize(Math.max(size, data.readVarInt()));
+        Arrays.fill(stacks, ItemStack.EMPTY);
         while (data.getByte(data.readerIndex()) != -1) {
             var item = data.readItem();
             var slot = data.readVarInt();

--- a/src/test/scripts/check_custom_item_handler_clears_missing_slots.ps1
+++ b/src/test/scripts/check_custom_item_handler_clears_missing_slots.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+
+$path = Join-Path $PSScriptRoot '../../main/java/com/gregtechceu/gtceu/api/transfer/item/CustomItemStackHandler.java'
+$source = Get-Content -Raw -Path $path
+
+$deserializePattern = 'public void deserializeNBT\(CompoundTag nbt\) \{\s*setSize\(Math\.max\(size, nbt\.getInt\("Size"\)\)\);\s*Arrays\.fill\(stacks, ItemStack\.EMPTY\);\s*ListTag tagList'
+if ($source -notmatch $deserializePattern) {
+    throw 'CustomItemStackHandler.deserializeNBT must clear existing slots before applying sparse non-empty NBT entries.'
+}
+
+$readBufPattern = 'public void readBuf\(LogicalSide side, @NotNull FriendlyByteBuf data\) \{\s*setSize\(Math\.max\(size, data\.readVarInt\(\)\)\);\s*Arrays\.fill\(stacks, ItemStack\.EMPTY\);\s*while \(data\.getByte\(data\.readerIndex\(\)\) != -1\)'
+if ($source -notmatch $readBufPattern) {
+    throw 'CustomItemStackHandler.readBuf must clear existing slots before applying sparse non-empty buffer entries.'
+}
+
+Write-Host 'CustomItemStackHandler missing slot clear regression check passed.'


### PR DESCRIPTION
## 修复内容
- `CustomItemStackHandler.deserializeNBT()` 在应用稀疏非空槽 NBT 前先清空当前 slots。
- `CustomItemStackHandler.readBuf()` 在应用稀疏非空槽网络数据前先清空当前 slots。
- 避免服务端清空槽位后，客户端或读回端因为同步包只包含非空槽而保留旧物品。
- 添加静态回归脚本，锁定两个读取入口都必须先清空缺失槽位。

## 验证
- RED：修复前 `powershell -NoProfile -ExecutionPolicy Bypass -File .\src\test\scripts\check_custom_item_handler_clears_missing_slots.ps1` 失败。
- GREEN：修复后同一脚本通过。
- `git diff --check`
- `.\gradlew.bat compileJava --no-daemon --console=plain`