### PR TITLE
Refactor item pipe model texture lookup

### DIFF
--- a/scripts/regression/item_pipe_values.ps1
+++ b/scripts/regression/item_pipe_values.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
+$sourcePath = Join-Path $repoRoot 'src\main\java\com\gregtechceu\gtceu\common\pipelike\item\ItemPipeType.java'
+$source = Get-Content -Raw $sourcePath
+
+if ($source -cmatch 'values\(\)\s*\[\s*this\.ordinal\(\)\s*-\s*4\s*\]') {
+    throw 'createPipeModel should use the cached VALUES array instead of calling enum values() in texture lambdas.'
+}
+
+if ($source -cnotmatch 'VALUES\s*\[\s*ordinal\(\)\s*-\s*4\s*\]\s*:\s*this') {
+    throw 'Restrictive item pipe texture lookup should explicitly map through the cached VALUES array.'
+}
+
+Write-Host 'ItemPipeType cached values regression check passed.'

--- a/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemPipeType.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/pipelike/item/ItemPipeType.java
@@ -58,10 +58,11 @@ public enum ItemPipeType implements IMaterialPipeType<ItemPipeProperties> {
 
     public PipeModel createPipeModel(Material material) {
         PipeModel model;
+        ItemPipeType textureType = isRestrictive() ? VALUES[ordinal() - 4] : this;
         if (material.hasProperty(PropertyKey.WOOD)) {
-            model = new PipeModel(thickness, () -> GTCEu.id("block/pipe/pipe_side_wood"), () -> GTCEu.id("block/pipe/pipe_%s_in_wood".formatted(this.isRestrictive() ? values()[this.ordinal() - 4].name : name)), null, null);
+            model = new PipeModel(thickness, () -> GTCEu.id("block/pipe/pipe_side_wood"), () -> GTCEu.id("block/pipe/pipe_%s_in_wood".formatted(textureType.name)), null, null);
         } else {
-            model = new PipeModel(thickness, () -> GTCEu.id("block/pipe/pipe_side"), () -> GTCEu.id("block/pipe/pipe_%s_in".formatted(this.isRestrictive() ? values()[this.ordinal() - 4].name : name)), null, null);
+            model = new PipeModel(thickness, () -> GTCEu.id("block/pipe/pipe_side"), () -> GTCEu.id("block/pipe/pipe_%s_in".formatted(textureType.name)), null, null);
         }
         if (isRestrictive()) {
             model.setSideOverlayTexture(GTCEu.id("block/pipe/pipe_restrictive"));


### PR DESCRIPTION
## Summary
- reuse ItemPipeType.VALUES when mapping restrictive pipe textures to base pipe textures
- avoid enum values() array cloning inside model texture lambdas
- add a regression script for the cached lookup

## Test Plan
- powershell -ExecutionPolicy Bypass -File scripts/regression/item_pipe_values.ps1
- git diff --check
- ./gradlew.bat compileJava --no-daemon --console=plain