### PR TITLE
fix: prevent ArrayIndexOutOfBoundsException in StaticFaceBakery.bakeQuad

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/util/StaticFaceBakery.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/util/StaticFaceBakery.java
@@ -107,6 +107,10 @@ public class StaticFaceBakery {
             blockfaceuv = recomputeUVs(face.uv, facing, transform.getRotation());
         }
 
+        if (blockfaceuv.uvs.length < 4) {
+            blockfaceuv = new BlockFaceUV(new float[] { 0.0F, 0.0F, 16.0F, 16.0F }, blockfaceuv.rotation);
+        }
+
         float[] afloat = new float[blockfaceuv.uvs.length];
         System.arraycopy(blockfaceuv.uvs, 0, afloat, 0, afloat.length);
         float f = sprite.uvShrinkRatio();


### PR DESCRIPTION
Guard against BlockFaceUV arrays with fewer than 4 elements by replacing them with a default full-face UV before accessing indices 0-3.

This fixes a crash when rendering GregTech machine items in FTB Quests chapter panels where the UV array length was unexpectedly 2.