### PR TITLE
修复HPCA烧坏后，换新的组件还会烧坏的问题

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -68,12 +68,15 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
 
     private static final double IDLE_TEMPERATURE = 200;
     private static final double DAMAGE_TEMPERATURE = 1000;
+    private static final double SAFE_TEMPERATURE = (IDLE_TEMPERATURE + DAMAGE_TEMPERATURE) / 2;
     private IFluidHandler coolantHandler;
 
     @AdditionalHolder
     private final HPCAGridHandler hpcaHandler;
     @SaveToDisk
     private double temperature = IDLE_TEMPERATURE; // start at idle temperature
+    @SaveToDisk
+    private boolean overheated;
     private final TimedProgressSupplier progressSupplier;
     @Nullable
     protected TickableSubscription tickSubs;
@@ -156,7 +159,7 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
 
     @Override
     public long requestCWU(long cwu, boolean simulate) {
-        if (isWorkingEnabled() && getRecipeLogic().isWorking()) {
+        if (!isOverheated() && isWorkingEnabled() && getRecipeLogic().isWorking()) {
             return hpcaHandler.allocateCWUt(getOffsetTimer(), cwu, simulate);
         }
         return 0;
@@ -175,20 +178,36 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
             } else {
                 getRecipeLogic().setWaiting(ActionResult.failInsufficientIn(EURecipeInfo.INSTANCE.getName()).reason());
             }
+            updateOverheatState();
             // forcibly use active coolers at full rate if temperature is half-way to damaging temperature
-            double midpoint = (DAMAGE_TEMPERATURE - IDLE_TEMPERATURE) / 2;
-            double temperatureChange = hpcaHandler.calculateTemperatureChange(coolantHandler, temperature >= midpoint) / 2.0;
+            double temperatureChange = hpcaHandler.calculateTemperatureChange(coolantHandler, overheated || temperature >= SAFE_TEMPERATURE) / 2.0;
             if (temperature + temperatureChange <= IDLE_TEMPERATURE) {
                 temperature = IDLE_TEMPERATURE;
             } else {
                 temperature += temperatureChange;
             }
-            if (temperature >= DAMAGE_TEMPERATURE) {
-                hpcaHandler.attemptDamageHPCA();
-            }
+            updateOverheatState();
             hpcaHandler.tick(getOffsetTimer());
         } else {
             temperature = Math.max(IDLE_TEMPERATURE, temperature - 0.25);
+            updateOverheatState();
+        }
+    }
+
+    private boolean isOverheated() {
+        return overheated || temperature >= DAMAGE_TEMPERATURE;
+    }
+
+    private void updateOverheatState() {
+        if (overheated) {
+            if (temperature <= SAFE_TEMPERATURE) {
+                overheated = false;
+            }
+            return;
+        }
+        if (temperature >= DAMAGE_TEMPERATURE) {
+            overheated = true;
+            hpcaHandler.damageHPCAComponent();
         }
     }
 
@@ -376,22 +395,17 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
         }
 
         /**
-         * Roll a 1/200 chance to damage a HPCA component marked as damageable. Randomly selects the component.
-         * If called every tick, this succeeds on average once every 10 seconds.
+         * Randomly damages one currently functional HPCA component.
          */
-        public void attemptDamageHPCA() {
-            // 1% chance each tick to damage a component if running too hot
-            if (GTValues.RNG.nextInt(200) == 0) {
-                // randomize which component is actually damaged
-                List<IHPCAComponentHatch> candidates = new ArrayList<>();
-                for (var component : components) {
-                    if (component.canBeDamaged()) {
-                        candidates.add(component);
-                    }
+        public void damageHPCAComponent() {
+            List<IHPCAComponentHatch> candidates = new ArrayList<>();
+            for (var component : components) {
+                if (component.canBeDamaged() && !component.isDamaged()) {
+                    candidates.add(component);
                 }
-                if (!candidates.isEmpty()) {
-                    candidates.get(GTValues.RNG.nextInt(candidates.size())).setDamaged(true);
-                }
+            }
+            if (!candidates.isEmpty()) {
+                candidates.get(GTValues.RNG.nextInt(candidates.size())).setDamaged(true);
             }
         }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/electric/research/HPCAMachine.java
@@ -100,17 +100,24 @@ public class HPCAMachine extends WorkableElectricMultiblockMachine implements IO
     public void onStructureFormed() {
         super.onStructureFormed();
         List<ICustomFluidStackHandler> coolantContainers = new ArrayList<>();
-        List<IHPCAComponentHatch> componentHatches = new ArrayList<>();
         for (IMultiPart part : getParts()) {
-            if (part instanceof IHPCAComponentHatch componentHatch) {
-                componentHatches.add(componentHatch);
-            } else if (part instanceof IWorkableMultiPart workableMultiPart) {
+            if (part instanceof IWorkableMultiPart workableMultiPart) {
                 for (var handlerList : workableMultiPart.getRecipeHandlers()) {
                     coolantContainers.addAll(handlerList.getCapabilities(ICustomFluidStackHandler.class));
                 }
             }
         }
         this.coolantHandler = new FluidHandlerList(coolantContainers);
+        refreshHPCAComponents();
+    }
+
+    public void refreshHPCAComponents() {
+        List<IHPCAComponentHatch> componentHatches = new ArrayList<>();
+        for (IMultiPart part : getParts()) {
+            if (part instanceof IHPCAComponentHatch componentHatch) {
+                componentHatches.add(componentHatch);
+            }
+        }
         this.hpcaHandler.onStructureForm(componentHatches);
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/hpca/HPCAComponentPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/hpca/HPCAComponentPartMachine.java
@@ -5,6 +5,7 @@ import com.gregtechceu.gtceu.api.capability.IHPCAComponentHatch;
 import com.gregtechceu.gtceu.api.machine.feature.IMachineModifyDrops;
 import com.gregtechceu.gtceu.api.machine.multiblock.part.MultiblockPartMachine;
 import com.gregtechceu.gtceu.common.data.GTBlocks;
+import com.gregtechceu.gtceu.common.machine.multiblock.electric.research.HPCAMachine;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.world.InteractionHand;
@@ -76,6 +77,16 @@ public abstract class HPCAComponentPartMachine extends MultiblockPartMachine
         if (this.damaged != damaged) {
             this.damaged = damaged;
             onChanged();
+            refreshHPCAControllers();
+        }
+    }
+
+    private void refreshHPCAControllers() {
+        if (getLevel() == null || getLevel().isClientSide) return;
+        for (var controller : getControllers()) {
+            if (controller.isFormed() && controller instanceof HPCAMachine hpcaMachine) {
+                hpcaMachine.refreshHPCAComponents();
+            }
         }
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/hpca/HPCAComputationPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/hpca/HPCAComputationPartMachine.java
@@ -35,11 +35,13 @@ public class HPCAComputationPartMachine extends HPCAComponentPartMachine impleme
 
     @Override
     public int getUpkeepEUt() {
+        if (isDamaged()) return 0;
         return GTValues.VA[advanced ? GTValues.IV : GTValues.EV];
     }
 
     @Override
     public int getMaxEUt() {
+        if (isDamaged()) return 0;
         return GTValues.VA[advanced ? GTValues.ZPM : GTValues.LuV];
     }
 
@@ -51,6 +53,7 @@ public class HPCAComputationPartMachine extends HPCAComponentPartMachine impleme
 
     @Override
     public int getCoolingPerTick() {
+        if (isDamaged()) return 0;
         return advanced ? 4 : 2;
     }
 


### PR DESCRIPTION
hpca内置了一个温度系统，然后缺冷却的时候温度会一直涨，无上限的那种

冷却剂足够之后会往下掉温度，但是前面升温多久，后面就要降温多久，而且还在危险温度1000度以上的时候会一直烧坏组件

所以加了一个新机制，过热冷却，超过1000度就烧坏一个组件，并且立刻更新hpca所有的状态（原本是不更新的），且停止输出CWU，开始冷却，直到回到600度，回到600度之后组件才开始回到工作。

对应的视觉效果还没加上

AI写的，我还没审