### PR TITLE
fix: stale 0-slot capability wrappers after chunk reload (pipes stop extracting from proxy hatches after relog)

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/machine/MetaMachine.java
@@ -413,8 +413,9 @@ public class MetaMachine implements ISync, ITickSubscription, IFancyTooltip, IPa
         itemHandlerModifiableCoverCache.clearCache();
         fluidHandlerModifiableCache.clearCache();
         fluidHandlerModifiableCoverCache.clearCache();
-        itemCapDirectionCache.clearCache();
-        fluidCapDirectionCache.clearCache();
+        // invalidate handed-out LazyOptionals so mods caching them (Pipez etc.) re-query
+        itemCapDirectionCache.clearCache(LazyOptional::invalidate);
+        fluidCapDirectionCache.clearCache(LazyOptional::invalidate);
     }
 
     public void clearInventory(ICustomItemStackHandler inventory) {

--- a/src/main/java/com/gregtechceu/gtceu/api/transfer/fluid/FluidHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/transfer/fluid/FluidHandlerList.java
@@ -17,17 +17,11 @@ import java.util.function.Predicate;
 public class FluidHandlerList implements ICustomFluidStackHandler, INBTSerializable<CompoundTag> {
 
     public final ICustomFluidStackHandler[] handlers;
-    protected final int size;
     @Setter
     protected Predicate<FluidStack> filter = GTUtil.FAVORABLE;
 
     public FluidHandlerList(ICustomFluidStackHandler... handlers) {
         this.handlers = handlers;
-        int size = 0;
-        for (var handler : handlers) {
-            size += handler.getTanks();
-        }
-        this.size = size;
     }
 
     public FluidHandlerList(List<ICustomFluidStackHandler> handlers) {
@@ -36,6 +30,12 @@ public class FluidHandlerList implements ICustomFluidStackHandler, INBTSerializa
 
     @Override
     public int getTanks() {
+        // computed dynamically: delegates (e.g. FluidTankProxyTrait) may change their tank
+        // count after this wrapper is created, such as when a multiblock forms after chunk load
+        int size = 0;
+        for (var handler : handlers) {
+            size += handler.getTanks();
+        }
         return size;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/api/transfer/item/ItemHandlerList.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/transfer/item/ItemHandlerList.java
@@ -7,19 +7,19 @@ import org.jetbrains.annotations.NotNull;
 public class ItemHandlerList implements ICustomItemStackHandler {
 
     protected final ICustomItemStackHandler[] handlers;
-    protected final int size;
 
     public ItemHandlerList(ICustomItemStackHandler... handlers) {
         this.handlers = handlers;
-        int size = 0;
-        for (var handler : handlers) {
-            size += handler.getSlots();
-        }
-        this.size = size;
     }
 
     @Override
     public int getSlots() {
+        // computed dynamically: delegates (e.g. ItemHandlerProxyTrait) may change their slot
+        // count after this wrapper is created, such as when a multiblock forms after chunk load
+        int size = 0;
+        for (var handler : handlers) {
+            size += handler.getSlots();
+        }
         return size;
     }
 

--- a/src/main/java/com/gregtechceu/gtceu/utils/cache/DirectionCache.java
+++ b/src/main/java/com/gregtechceu/gtceu/utils/cache/DirectionCache.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 @SuppressWarnings("unchecked")
@@ -54,5 +55,26 @@ public class DirectionCache<T> {
     public void clearCache() {
         any = null;
         Arrays.fill(array, null);
+    }
+
+    /**
+     * Clears the cache and passes each previously cached value to {@code onClear},
+     * e.g. to {@link net.minecraftforge.common.util.LazyOptional#invalidate()} handed-out capabilities
+     * so that other mods holding them know to re-query.
+     * Values are removed from the cache before the callback runs.
+     */
+    public void clearCache(@NotNull Consumer<? super T> onClear) {
+        var oldAny = any;
+        any = null;
+        if (oldAny != null && oldAny != NULL) {
+            onClear.accept((T) oldAny);
+        }
+        for (int i = 0; i < array.length; i++) {
+            var old = array[i];
+            array[i] = null;
+            if (old != null && old != NULL) {
+                onClear.accept((T) old);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem / 问题

After a player relogs (chunk reload), external pipes set to extract from proxy-based hatches — e.g. GTOCore's `PrimitiveBlastFurnaceHatch`, or this repo's `CokeOvenHatch` — permanently stop extracting until the pipe block is broken and re-placed.

玩家重新进入服务器（区块重载）后，设置为从代理型仓室（如 GTOCore 的 `PrimitiveBlastFurnaceHatch`、本仓库的 `CokeOvenHatch`）抽取物品的管道（Pipez 等）会永久停止抽取，直到拆掉重放管道才恢复。

### Root cause / 原因分析

1. On chunk load the multiblock re-forms **a few ticks later** than block entities load. Until `addedToController` runs, `ItemHandlerProxyTrait`/`FluidTankProxyTrait` proxies are `null` (0 slots / 0 tanks).
2. If any mod queries the item/fluid capability during that window (Pipez extract pipes poll every tick), `MetaMachine#getItemHandlerCap` builds an `IOFilteredInvWrapper extends ItemHandlerList` over the proxy traits. `ItemHandlerList` **froze its slot count in the constructor** (`this.size = …`), so the wrapper is permanently a 0-slot inventory even after the proxies are set. Same for `FluidHandlerList#getTanks()`.
3. The wrapper is handed out inside a `LazyOptional` (cached in `itemCapDirectionCache`). When the multiblock forms, `MultiblockPartMachine#addedToController` → `clearDirectionCache()` drops the cached `LazyOptional` **without calling `invalidate()`**. Mods that cache capabilities (Pipez `Connection#getItemHandler` only re-queries when `!isPresent()`) keep the stale 0-slot wrapper forever.

Breaking and re-placing the pipe creates a fresh block entity → fresh query → works again, which matches the reported symptom exactly.

### Fix / 修复

* `ItemHandlerList#getSlots()` and `FluidHandlerList#getTanks()` are now computed dynamically from the delegates instead of being frozen at construction time (all other methods of these classes already iterate dynamically). A wrapper created before the multiblock forms now self-heals once the proxies are set.
* `MetaMachine#clearDirectionCache()` now **invalidates** the handed-out `LazyOptional`s (new `DirectionCache#clearCache(Consumer)` overload), as required by the Forge capability contract, so capability-caching mods promptly re-query on structure form/unform, rotation and unload.

### Testing / 测试

* `./gradlew compileJava` passes.
* Runtime verification against the compiled classes, simulating Pipez's caching contract (`Connection#getItemHandler` re-queries only when `!isPresent()`):
  * **pre-fix `ItemHandlerList`**: wrapper built while delegates report 0 slots stays frozen at 0 after the delegates gain slots → bug reproduced;
  * **patched classes**: the same wrapper reports the new slot count (fix 1), and `clearCache(LazyOptional::invalidate)` flips the handed-out optional to `!isPresent()` so a caching mod re-queries and gets a fresh, correct capability (fix 2), while the old plain `clearCache()` demonstrably left the stale optional "present" forever.

Reported by a GTO player: Pipez extract pipes on a Primitive Blast Furnace hatch die after every relog until re-placed.

### Disclaimer / 声明

Full disclosure: I don't know Java myself — I fed everything I knew about the bug to Claude (Fable 5), which did the investigation, the patch and the verification above. Please review carefully before merging :)

说明：我本人不会 Java —— 我把我所知道的 bug 信息都交给了 Claude（Fable 5），由它完成了上面的分析、修复和验证。合并前请仔细审查 :)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
