### PR TITLE
fix: 修复转子镀层耐久度消耗异常的问题

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/item/tool/CoatedTurbineRotorBehaviour.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/item/tool/CoatedTurbineRotorBehaviour.java
@@ -134,14 +134,14 @@ public class CoatedTurbineRotorBehaviour extends TurbineRotorBehaviour {
      */
     @Override
     public void setPartDamage(ItemStack itemStack, int resultDamage) {
-        if (resultDamage > getDamage(itemStack) &&
+        if (resultDamage > getPartDamage(itemStack) &&
                 getCoatDamage(itemStack) < getCoatMaxDamage(itemStack) &&
                 rd.nextInt(100) < 95 && !isCoatingMagical(itemStack)) {
-            setCoatDamage(itemStack, (int) Math.min(getCoatDamage(itemStack) + resultDamage - getDamage(itemStack), getCoatMaxDamage(itemStack)));
+            setCoatDamage(itemStack, (int) Math.min(getCoatDamage(itemStack) + resultDamage - getPartDamage(itemStack), getCoatMaxDamage(itemStack)));
             return;
         } else if (isCoatingMagical(itemStack)) {
             // 魔法镀层与本体耐久同时损失
-            setCoatDamage(itemStack, (int) (getCoatDamage(itemStack) + resultDamage - getDamage(itemStack)));
+            setCoatDamage(itemStack, (int) (getCoatDamage(itemStack) + resultDamage - getPartDamage(itemStack)));
         }
         super.setPartDamage(itemStack, resultDamage);
     }


### PR DESCRIPTION
# 问题
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1336
转子镀层耐久消耗过快

# 修复方式
GetDamage是获取把手伸进转子的伤害，这里应该是和GetPartDamage误用了导致转子耐久异常消耗。

将源代码中GetDamage替换为GetPartDamage