### PR TITLE
fix: 修复没有方块实体时机器不渲染

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/MachineRenderer.java
+++ b/src/main/java/com/gregtechceu/gtceu/client/renderer/machine/MachineRenderer.java
@@ -148,6 +148,18 @@ public class MachineRenderer extends TextureOverrideRenderer
                 }
                 return quads;
             }
+
+            // No machine: either no level/pos at all, or the level has no block entity at that position, which is
+            // what fake render levels do (the Building Gadgets copy/paste preview, for one). Covers, auto IO
+            // overlays and formed part models are unavailable, but the machine itself can still be rendered from
+            // the block state alone, the same way the item model is rendered.
+            var upwardsFacing = state.hasProperty(MetaMachineBlock.UPWARDS_FACING_PROPERTY) ?
+                    state.getValue(MetaMachineBlock.UPWARDS_FACING_PROPERTY) : Direction.NORTH;
+            var quads = new LinkedList<BakedQuad>();
+            renderMachine(quads, machineBlock.definition, null, frontFacing, side, rand,
+                    side == null ? null : ModelFactory.modelFacing(side, frontFacing),
+                    GTMatrixUtils.createRotationState(frontFacing, upwardsFacing));
+            return quads;
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
## 问题

`MachineRenderer#renderModel` 只要在该位置取不到方块实体（`level.getBlockEntity(pos)`），就直接 `return Collections.emptyList()`，一个面都不画。

假世界（fake render level）就是这种情况。以 Building Gadgets 的复制/粘贴预览为例：它先用空的 `ModelData` 向模型索取面片来给方块分类，机器返回 0 个面片，于是被判定为「没有模型，走方块实体渲染器」——而机器的外观本来就不是由 BER 提供的，结果就是**机器在预览里完全不可见**。

## 改动

在拿不到机器时，回退到物品渲染已经在用的那条「无机器实例」路径：`renderMachine(quads, definition, null, ...)`。朝向与竖直朝向从 `BlockState` 读取（`getFrontFacing(state)` / `UPWARDS_FACING_PROPERTY`）。

盖板（cover）、自动输出图标、成形后的多方块部件模型都需要机器实例，没有就不画；但机器本体可以完全依据 `BlockState` 渲染出来。

真实世界的渲染路径完全不变（那里一定有方块实体，走的还是原来的分支）。顺带也修好了「区块重建早于方块实体加载时机器短暂隐形」的老问题。

## 测试

开发环境客户端 + Building Gadgets 实测：

| | 修改前 | 修改后 |
|---|---|---|
| 电炉 | 0 面片（判定为无模型） | 8 面片 |
| 粉碎机 | 0 | 10 |
| 量子箱 | 0 | 16 |
| 蒸汽粉碎机 | 0 | 10 |