### PR TITLE
feat: 输出总线支持物品过滤器（#1715）

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandler.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandler.java
@@ -35,7 +35,11 @@ import javax.annotation.ParametersAreNonnullByDefault;
 public abstract class FilterHandler<T, F extends Filter<T, F>> implements IFieldDataHolder {
 
     private final LazyFieldDataManager fieldDataManager = new LazyFieldDataManager(this);
-    private final CoverBehavior container;
+    /**
+     * Cover or machine that owns this filter (both implement {@link IFieldDataHolder}).
+     * Upstream uses the same pattern so item buses can host filters like covers.
+     */
+    private final IFieldDataHolder container;
 
     @Getter
     @SaveToDisk(defaultValueGetter = "getDefaultItem")
@@ -55,7 +59,7 @@ public abstract class FilterHandler<T, F extends Filter<T, F>> implements IField
     @NotNull
     private Consumer<F> onFilterUpdated = filter -> {};
 
-    public FilterHandler(CoverBehavior container) {
+    public FilterHandler(IFieldDataHolder container) {
         this.container = container;
     }
 
@@ -148,10 +152,15 @@ public abstract class FilterHandler<T, F extends Filter<T, F>> implements IField
         if (!this.filterItem.isEmpty()) {
             this.filter = loadFilter(this.filterItem);
             filter.setOnUpdated(this.onFilterUpdated);
-            if (filter instanceof SmartItemFilter smart && container instanceof CoverBehavior cover && cover.coverHolder instanceof MachineCoverContainer mcc) {
-                var machine = MetaMachine.getMachine(mcc.holder());
-                if (machine != null) {
+            if (filter instanceof SmartItemFilter smart) {
+                if (container instanceof MetaMachine machine) {
                     smart.setModeFromMachine(machine.getDefinition().getName());
+                } else if (container instanceof CoverBehavior cover &&
+                        cover.coverHolder instanceof MachineCoverContainer mcc) {
+                    var machine = MetaMachine.getMachine(mcc.holder());
+                    if (machine != null) {
+                        smart.setModeFromMachine(machine.getDefinition().getName());
+                    }
                 }
             }
             this.onFilterLoaded.accept(this.filter);

--- a/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandlers.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/cover/filter/FilterHandlers.java
@@ -1,13 +1,14 @@
 package com.gregtechceu.gtceu.api.cover.filter;
 
-import com.gregtechceu.gtceu.api.cover.CoverBehavior;
-
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
+import com.gto.datasynclib.IFieldDataHolder;
+
 public interface FilterHandlers {
 
-    static FilterHandler<ItemStack, ItemFilter> item(CoverBehavior container) {
+    /** Host may be a cover or a machine (e.g. item export bus). */
+    static FilterHandler<ItemStack, ItemFilter> item(IFieldDataHolder container) {
         return new FilterHandler<>(container) {
 
             @Override
@@ -27,7 +28,8 @@ public interface FilterHandlers {
         };
     }
 
-    static FilterHandler<FluidStack, FluidFilter> fluid(CoverBehavior container) {
+    /** Host may be a cover or a machine. */
+    static FilterHandler<FluidStack, FluidFilter> fluid(IFieldDataHolder container) {
         return new FilterHandler<>(container) {
 
             @Override

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -1,6 +1,9 @@
 package com.gregtechceu.gtceu.common.machine.multiblock.part;
 
 import com.gregtechceu.gtceu.api.blockentity.MetaMachineBlockEntity;
+import com.gregtechceu.gtceu.api.cover.filter.FilterHandler;
+import com.gregtechceu.gtceu.api.cover.filter.FilterHandlers;
+import com.gregtechceu.gtceu.api.cover.filter.ItemFilter;
 import com.gregtechceu.gtceu.api.gui.GuiTextures;
 import com.gregtechceu.gtceu.api.gui.fancy.ConfiguratorPanel;
 import com.gregtechceu.gtceu.api.gui.fancy.TabsWidget;
@@ -28,10 +31,12 @@ import com.lowdragmc.lowdraglib.syncdata.ISubscription;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -67,8 +72,19 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
     @SaveToDisk(defaultValue = "0")
     protected int priority;
 
+    /**
+     * Item filter for export buses (upstream CEu #4337 / #4686).
+     * Insert a filter item in the bus GUI; only matching items can enter the inventory
+     * (and thus be outputted by the multiblock / auto-export).
+     */
+    @Getter
+    @SaveToDisk
+    @SyncToClient
+    protected final FilterHandler<ItemStack, ItemFilter> filterHandler;
+
     public ItemBusPartMachine(MetaMachineBlockEntity holder, int tier, IO io, Object... args) {
         super(holder, tier, io);
+        this.filterHandler = FilterHandlers.item(this);
         this.inventory = createInventory(args);
         this.circuitInventory = createCircuitItemHandler(io);
         if (io == IO.IN) this.workingEnabled = false;
@@ -83,8 +99,15 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
         return sizeRoot * sizeRoot;
     }
 
+    protected boolean matchesFilter(ItemStack stack) {
+        if (filterHandler.isFilterPresent()) {
+            return filterHandler.getFilter().test(stack);
+        }
+        return true;
+    }
+
     protected NotifiableItemStackHandler createInventory(Object... args) {
-        return new NotifiableItemStackHandler(this, getInventorySize(), io);
+        return new NotifiableItemStackHandler(this, getInventorySize(), io).setFilter(this::matchesFilter);
     }
 
     protected NotifiableItemStackHandler createCircuitItemHandler(Object... args) {
@@ -269,6 +292,11 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
         var group = new WidgetGroup(0, 0, 18 * rowSize + 16, 18 * colSize + 16);
         var container = new WidgetGroup(4, 4, 18 * rowSize + 8, 18 * colSize + 8);
         int index = 0;
+        // Output bus only: filter item slot (CEu #4686 layout)
+        if (this.io == IO.OUT) {
+            group.addWidget(filterHandler.createFilterSlotUI(71 + (18 * rowSize) / 2, 35 + 9 * rowSize)
+                    .setHoverTooltips(Component.translatable("cover.item_filter.title")));
+        }
         for (int y = 0; y < colSize; y++) {
             for (int x = 0; x < rowSize; x++) {
                 container.addWidget(new SlotWidget(getInventory().storage, index++, 4 + x * 18, 4 + y * 18, true, io.support(IO.IN)).setBackgroundTexture(GuiTextures.SLOT).setIngredientIO(this.io == IO.IN ? IngredientIO.INPUT : IngredientIO.OUTPUT));

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -298,12 +298,13 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
             rowSize = 4;
             colSize = 2;
         }
-        var group = new WidgetGroup(0, 0, 18 * rowSize + 16, 18 * colSize + 16);
+        // Output buses reserve an extra row below the grid for the filter slot; the upstream
+        // floating position (71 + 9 * rowSize) collides with the grid from LuV (7 columns) upward.
+        var group = new WidgetGroup(0, 0, 18 * rowSize + 16, 18 * colSize + 16 + (this.io == IO.OUT ? 24 : 0));
         var container = new WidgetGroup(4, 4, 18 * rowSize + 8, 18 * colSize + 8);
         int index = 0;
-        // Output bus only: filter item slot (CEu #4686 layout)
         if (this.io == IO.OUT) {
-            group.addWidget(filterHandler.createFilterSlotUI(71 + (18 * rowSize) / 2, 35 + 9 * rowSize)
+            group.addWidget(filterHandler.createFilterSlotUI((18 * rowSize + 16) / 2 - 9, 18 * colSize + 18)
                     .setHoverTooltips(Component.translatable("cover.item_filter.title")));
         }
         for (int y = 0; y < colSize; y++) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -107,7 +107,12 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
     }
 
     protected NotifiableItemStackHandler createInventory(Object... args) {
-        return new NotifiableItemStackHandler(this, getInventorySize(), io).setFilter(this::matchesFilter);
+        // Filter applies to export buses only (CEu #4337 / #4686); import buses stay unrestricted.
+        var inv = new NotifiableItemStackHandler(this, getInventorySize(), io);
+        if (io == IO.OUT) {
+            inv.setFilter(this::matchesFilter);
+        }
+        return inv;
     }
 
     protected NotifiableItemStackHandler createCircuitItemHandler(Object... args) {

--- a/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/multiblock/part/ItemBusPartMachine.java
@@ -126,6 +126,10 @@ public class ItemBusPartMachine extends WorkableTieredIOPartMachine implements I
     @Override
     public void onMachineRemoved() {
         clearInventory(getInventory().storage);
+        // Drop the filter like covers do (ConveyorCover#getAdditionalDrops) and upstream CEu #4686.
+        if (!filterHandler.getFilterItem().isEmpty()) {
+            Block.popResource(getLevel(), getPos(), filterHandler.getFilterItem());
+        }
     }
 
     @Override


### PR DESCRIPTION
## 摘要
移植 GregTechCEu 上游 [Output bus filtering #4337](https://github.com/GregTechCEu/GregTech-Modern/pull/4337) 与 [Fix up output item bus filter #4686](https://github.com/GregTechCEu/GregTech-Modern/pull/4686),实现普通**输出总线**物品过滤,并修复移植中发现的两个问题。

对应建议:https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1715

## 行为
- 打开**物品输出总线** GUI,库存网格**正下方居中**有过滤器槽
- 放入物品过滤器(简易/智能/标签/矿辞等,与过滤覆盖板相同物品)
- 仅**通过过滤器**的物品可进入总线库存(多方块输出 / 自动输出均受约束)
- 未装过滤器时与原先一致;破坏总线时过滤器随库存一起掉落

## 实现
- `FilterHandler` / `FilterHandlers`:宿主从 `CoverBehavior` 扩展为 `IFieldDataHolder`(Cover 与 Machine 均可)
- `ItemBusPartMachine`:持有 `filterHandler`,`inventory.setFilter(matchesFilter)`,仅 `IO.OUT` 显示过滤槽
- Smart 过滤器在机器上可按总线定义名自动选模式

## 对上游的两处修正
1. **破坏总线掉落过滤器**:上游在 `onMachineDestroyed` 掉落 filterItem,本仓对应钩子是 `onMachineRemoved`,补上掉落(与 `ConveyorCover#getAdditionalDrops` 行为一致),避免过滤器凭空消失。
2. **过滤槽布局**:上游浮动坐标 `(71+9r, 35+9r)` 每级仅右移 9px,而库存网格每级加宽 18px——LuV(7 列)起网格追上过滤槽开始重叠,ZPM+ 完全被网格盖住不可见。改为输出总线在网格下方预留一行,过滤槽水平居中,任意等级不重叠。

## 测试(0.5.7 dev 实测,含服务端日志验证)
- [x] 过滤器插入正确到达服务端(`FilterHandler.updateFilter` 服务端日志确认)
- [x] 关闭/重开 GUI 过滤器保持(客户端同步正常)
- [x] **存档退出世界重进后过滤器保留**(`@SaveToDisk` 嵌套 holder 持久化验证)
- [x] 扳手拆除时过滤器与库存一起掉落(服务端 `onMachineRemoved` 日志确认)
- [x] 输入总线无过滤槽、行为不变
- [x] LuV/ZPM+ 高等级输出总线过滤槽位置正确(布局修复后)
- [ ] 白名单过滤约束多方块输出(逻辑与上游一致,读同一 `filterItem` 字段,待日常游戏验证)

🤖 Generated with [Claude Code](https://claude.com/claude-code)