### PR TITLE
fix: 锻造锤掉落转换缺少 BLOCK_ENTITY loot 参数（修复连锁挖铁砧后全世界无掉落物）

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/item/tool/ToolHelper.java
@@ -1,5 +1,6 @@
 package com.gregtechceu.gtceu.api.item.tool;
 
+import com.gregtechceu.gtceu.GTCEu;
 import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.item.IElectricItem;
@@ -356,7 +357,17 @@ public class ToolHelper {
      */
     public static void applyHammerDropConversion(ServerLevel world, BlockPos pos, ItemStack tool, BlockState state, List<ItemStack> drops, int fortune, float dropChance, RandomSource random) {
         if (ToolHelper.is(tool, GTToolType.HARD_HAMMER)) {
-            for (ItemStack silktouchDrop : ToolHelper.getSilkTouchDrop(world, pos, state)) {
+            List<ItemStack> silktouchDrops;
+            try {
+                silktouchDrops = ToolHelper.getSilkTouchDrop(world, pos, state);
+            } catch (Exception e) {
+                // The conversion is purely cosmetic, so a modded getDrops with unusual loot-param
+                // requirements must never break the block-break chain: with FTB Ultimine this used to
+                // leak its drop-capture flag and swallow every item drop in the world (GTO #1788).
+                GTCEu.LOGGER.error("Failed to compute hammer drop conversion for {} at {}", state, pos, e);
+                return;
+            }
+            for (ItemStack silktouchDrop : silktouchDrops) {
                 var item = silktouchDrop.getItem();
                 if (item == Items.AIR) continue;
                 for (var tagKey : item.builtInRegistryHolder().tags) {
@@ -653,8 +664,12 @@ public class ToolHelper {
         ItemStack tool = GTMaterialItems.TOOL_ITEMS.get(GTMaterials.Neutronium, GTToolType.PICKAXE).get().get();
         tool.enchant(Enchantments.SILK_TOUCH, 1);
 
+        // BLOCK_ENTITY must be supplied like vanilla's Block.dropResources does: some modded getDrops
+        // require it (Apotheosis' anvil reads its block entity for enchantments) and throw
+        // NoSuchElementException otherwise.
         return state.getDrops(new LootParams.Builder(world).withParameter(LootContextParams.BLOCK_STATE, state)
                 .withParameter(LootContextParams.ORIGIN, Vec3.atCenterOf(origin))
-                .withParameter(LootContextParams.TOOL, tool));
+                .withParameter(LootContextParams.TOOL, tool)
+                .withOptionalParameter(LootContextParams.BLOCK_ENTITY, world.getBlockEntity(origin)));
     }
 }


### PR DESCRIPTION
修复 GregTech-Odyssey/GregTech-Odyssey#1788。

## 根因链（三层）

**① GTM 直接原因**：`ToolHelper.getSilkTouchDrop` 构造 `LootParams` 时只给了 `BLOCK_STATE / ORIGIN / TOOL`。整合包中铁砧被 Apotheosis 替换（`ApothAnvilBlock`，可附魔、带 BlockEntity），其 `getDrops` 对 `BLOCK_ENTITY` 是必需参数 → `NoSuchElementException`。该路径为**锻造锤专属**（`applyHammerDropConversion` 锤碎转换），普通镐不受影响。

**② FTB Ultimine 放大**（上游缺陷，已反汇编 2001.1.8 确认）：`blockBroken` 设 `isBreakingBlock = true` 后进入连锁循环，方法**无任何 try/finally**；捕获期间 `entityJoinedWorld` 会吞掉**任意维度**新生成的 `ItemEntity`（并 `kill()` 经验球）。异常从循环炸出 → 标志永久卡死 → 全世界掉落物黑洞。

**③ 无感知**：破坏方块跑在网络包任务里，`PacketUtils` "suppressing error" 吞掉异常，玩家看不到任何崩溃。

用户日志证据：
```
21:59:43  Alcox233 cheated in 64 anvil
21:59:48  NoSuchElementException: minecraft:block_entity
          at ApothAnvilBlock.getDrops ← ToolHelper.getSilkTouchDrop
          ← applyHammerDropConversion ← FTBUltimine.blockBroken(261)
          "Failed to handle packet ... suppressing error"
```

## 修复

1. `getSilkTouchDrop` 补上 `withOptionalParameter(BLOCK_ENTITY, world.getBlockEntity(origin))`——与原版 `Block.dropResources` 的参数集对齐
2. `applyHammerDropConversion` 加 try/catch：锤碎转换是锦上添花的功能，任何 mod 的 loot 怪癖都不应炸断整个方块破坏链

## 恢复说明（受影响玩家）

标志是 mod 实例内存字段：**退出存档不会恢复，需重启整个游戏**；存档无损，但卡死期间产生的掉落物已湮灭。

## 后续

GTOCore 侧另有兜底（`FTBUltimineMixin` 包裹连锁循环内的 `destroyBlock`），防止未来任何 mod 异常再次触发同类灾难。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
