### PR TITLE
fix: 超净间不应在每个serverTick()都获得洁净度

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/machine/trait/CleanroomLogic.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/machine/trait/CleanroomLogic.java
@@ -78,6 +78,7 @@ public class CleanroomLogic extends RecipeLogic {
                 // increase progress
                 if (progress++ < getMaxProgress()) {
                     machine.onWorking();
+                    return;
                 }
                 progress = 0;
                 adjustCleanAmount(false);


### PR DESCRIPTION
## 描述
commit 03d53193 删除了`CleanroomLogic.serverTick()`内部的一处return，使得超净间在WORKING状态时的每个`serverTick()`都会获得洁净度，然后将机器运行进度重置为0。
本PR修改后，仅在`progress >= getMaxProgress()`时才会调用`adjustCleanAmount(false)`同时重置`progress = 0`

<img width="857" height="529" alt="4b64a799-103d-401e-ab4d-6aca6702ea9a" src="https://github.com/user-attachments/assets/69a62c7b-1d09-4268-957b-d26ebee0a79e" />

## Related
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1787


