### PR TITLE
fix: 流体合成时NBT丢失

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
+++ b/src/main/java/com/gregtechceu/gtceu/api/recipe/ingredient/FluidIngredient.java
@@ -251,7 +251,7 @@ public final class FluidIngredient extends ContentInner implements Predicate<Flu
         if (this.stacks == null) {
             switch (value) {
                 case null -> this.stacks = EMPTY_STACKS;
-                case Fluid fluid -> this.stacks = new FluidStack[] { new FluidStack(fluid, getAmount()) };
+                case Fluid fluid -> this.stacks = new FluidStack[] { new FluidStack(fluid, getAmount(), nbt) };
                 case TagKey tagKey -> {
                     Optional<HolderSet.Named<Fluid>> optional = BuiltInRegistries.FLUID.getTag(tagKey);
                     if (optional.isPresent()) {


### PR DESCRIPTION
## 描述
调用链 `IRecipeLogicMachine.matchRecipeOutput(GTRecipe recipe)` -> `RecipeHandlerUnit.handleRecipeFluid(...)` -> `NotifiableFluidTank.handleRecipeFluid(...)` -> `NotifiableFluidTank.handleRecipe(...)`中调用`ingredient.inner.getFluidStack(ingredient.getIntAmount())`拿到的`FluidStack`中的nbt为null，其真实的nbt处于外层包装`FluidIngredient`中。
进一步排查确认`NotifiableFluidTank.handleRecipe(...)` -> `getFluidStack(...)` -> `getStacks()` 的过程中直接拿到了`FluidIngredient.stacks`对象，这个对象是于早些时间的`NotifiableFluidTank.handleRecipeSimulate(...)` -> `getFluidStack(...)` -> `getStacks()`创建的（即本PR直接修改的位置），而它在组装`FluidStack`对象时没有带上外层`FluidIngredient`包装的nbt。

## Related
https://github.com/GregTech-Odyssey/GregTech-Odyssey/issues/1790