### PR TITLE
fix(cover): 修正末影紅石鏈接在沒有訊號來源時仍輸出 15

### DIFF
--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/AbstractEnderLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/AbstractEnderLinkCover.java
@@ -120,9 +120,16 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
     public void setWorkingEnabled(boolean isWorkingAllowed) {
         if (this.isWorkingEnabled != isWorkingAllowed) {
             this.isWorkingEnabled = isWorkingAllowed;
+            if (!isWorkingAllowed) onTransferStopped();
             subscriptionHandler.updateSubscription();
         }
     }
+
+    /**
+     * 傳輸停止時（切換 IO 模式、或關閉工作開關）呼叫。
+     * update() 之後不會再跑，子類別必須在這裡清掉自己殘留的輸出與頻道值，否則會被永久凍結在最後一次的狀態。
+     */
+    protected void onTransferStopped() {}
 
     @Override
     public Widget createUIWidget() {
@@ -132,6 +139,7 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
 
     public void setIo(IO io) {
         if (io == IO.IN || io == IO.OUT) {
+            if (this.io != io) onTransferStopped();
             this.io = io;
             subscriptionHandler.updateSubscription();
         }
@@ -161,9 +169,12 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
 
     protected void setChannelName(String name) {
         if (isRemote()) return;
-        VirtualEnderRegistry.getInstance().deleteEntryIf(getOwner(), getEntryType(), getChannelName(), VirtualEntry::canRemove);
+        var oldChannel = getChannelName();
         this.colorStr = name;
+        // 先加入新頻道（setEntry 會順便把自己從舊 entry 移除），再回頭清舊 entry；
+        // 反過來做的話舊頻道永遠會因為「自己還在成員裡」而通不過 canRemove()。
         setVirtualEntry();
+        VirtualEnderRegistry.getInstance().deleteEntryIf(getOwner(), getEntryType(), oldChannel, VirtualEntry::canRemove);
     }
 
     protected final String getChannelName(VirtualEntry entry) {
@@ -172,9 +183,11 @@ public abstract class AbstractEnderLinkCover<T extends VirtualEntry> extends Cov
 
     protected void setPermission(Permissions permission) {
         if (isRemote()) return;
-        VirtualEnderRegistry.getInstance().deleteEntryIf(getOwner(), getEntryType(), getChannelName(), VirtualEntry::canRemove);
+        var oldOwner = getOwner();
+        var oldChannel = getChannelName();
         this.permission = permission;
         setVirtualEntry();
+        VirtualEnderRegistry.getInstance().deleteEntryIf(oldOwner, getEntryType(), oldChannel, VirtualEntry::canRemove);
     }
 
     protected void setVirtualEntry() {

--- a/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderRedstoneLinkCover.java
+++ b/src/main/java/com/gregtechceu/gtceu/common/cover/ender/EnderRedstoneLinkCover.java
@@ -27,10 +27,19 @@ public class EnderRedstoneLinkCover extends AbstractEnderLinkCover<VirtualRedsto
 
     public EnderRedstoneLinkCover(CoverDefinition definition, ICoverable coverHolder, Direction attachedSide) {
         super(definition, coverHolder, attachedSide);
-        if (!isRemote()) {
-            uuid = UUID.randomUUID();
-            setVirtualEntry();
-        } else uuid = null;
+        // 不在建構子註冊頻道：覆蓋板從 NBT 載入時是「先跑建構子、之後才還原 uuid/colorStr」，
+        // 此時 colorStr 還是預設的 FFFFFFFF、uuid 也還沒還原，
+        // 在這裡註冊等於每次區塊載入都往預設頻道塞一個拋棄式 UUID，而且永遠不會被移除。
+        // 改到 onLoad()（NBT 已還原、level 也已設定）再註冊。
+        uuid = null;
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if (isRemote()) return;
+        if (uuid == null) uuid = UUID.randomUUID();
+        setVirtualEntry();
     }
 
     @Override
@@ -82,12 +91,32 @@ public class EnderRedstoneLinkCover extends AbstractEnderLinkCover<VirtualRedsto
 
     @Override
     public void onRemoved() {
-        storage.removeMember(uuid);
+        if (!isRemote() && storage != null) storage.removeMember(uuid);
         super.onRemoved();
     }
 
+    @Override
+    public void onUnload() {
+        // 區塊卸載時也要退出頻道，否則本板子最後讀到的值會永遠留在頻道裡，
+        // 讓其他 OUT 板子一直讀到一個早已沒有來源的訊號。
+        if (!isRemote() && storage != null) storage.removeMember(uuid);
+        super.onUnload();
+    }
+
+    @Override
+    protected void onTransferStopped() {
+        if (isRemote()) return;
+        // 離開 OUT：redstoneSignalOutput 只有 transfer() 的 OUT 分支會寫，
+        // 不在這裡歸零的話機器那一面會永遠卡在最後一次的輸出值。
+        setRedstoneSignalOutput(0);
+        // 離開 IN：不再由本板子撐住頻道值。
+        if (storage != null) storage.setSignal(uuid, 0);
+    }
+
     protected int getSignalInput() {
+        // Level#getSignal 的 Direction 是「接收方 -> 來源」的方向，也就是 attachedSide 本身；
+        // 傳 getOpposite() 會讀成別的面（對照 MachineControllerCover#getInputSignal）。
         return coverHolder.getLevel().getSignal(coverHolder.getPos().relative(attachedSide),
-                attachedSide.getOpposite());
+                attachedSide);
     }
 }


### PR DESCRIPTION
EnderRedstoneLinkCover 的輸出取自頻道內所有成員值的最大值，但成員值在數個路徑上 會被孤立，而 redstoneSignalOutput 又只有 transfer() 的 OUT 分支會寫， 導致它一旦被寫成 15 就再也降不下來。

- 建構子在 NBT 還原「之前」就用隨機 UUID 註冊到預設頻道 FFFFFFFF：此時 uuid 與 colorStr 都還沒還原，於是每次區塊載入都留下一個永遠不會被移除的成員， 也讓 canRemove() 永遠為 false、頻道再也無法回收。改到 onLoad()（欄位已還原、 level 已設定）再註冊。
- onUnload() 沒有 removeMember()：區塊卸載後該成員最後讀到的值會永久留在頻道裡， 其他 OUT 覆蓋板會一直讀到一個早已沒有來源的訊號。
- setIo() 與 setWorkingEnabled(false) 不會清掉 redstoneSignalOutput：切換成 IN 或關閉工作開關之後，機器那一面會永遠卡在最後一次的輸出值，且會存進 NBT。 新增 onTransferStopped() hook 一併歸零輸出與自己的頻道值。
- getSignalInput() 傳入 attachedSide.getOpposite()，但 Level#getSignal 的 Direction 語意是「接收方 -> 來源」，應為 attachedSide；對照 MachineControllerCover#getInputSignal 與 ControlPartMachine 皆是如此。
- setChannelName()/setPermission() 在把自己移出舊頻道之前就呼叫 deleteEntryIf， 舊頻道永遠通不過 canRemove()。改為先加入新頻道，再回收舊的。